### PR TITLE
[FIX] github action deploy docs 생성시 example 렌더링 문제 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,16 +120,19 @@ jobs:
 
       - name: Setup ReDoc
         run: |
-          npm install -g redoc-cli
+          npm i -g @redocly/cli@latest
 
       - name: Create Output folder
         run: mkdir -p ./docs
 
       - name: Fix Redoc
-        run: python3 ./fix_redoc.py  ./openapi3.yaml  > openapi-fixed.yaml
+        run: python3 ./fix_redoc.py  ./openapi3.yaml  > openapi.yaml
 
       - name: Generate API Docs
-        run: redoc-cli bundle ./openapi-fixed.yaml -o ./docs/index.html
+        run: redoc-cli bundle ./openapi.yaml -o ./docs/index.html
+
+      - name: clean up
+        run: rm openapi3.yaml fix_redoc.py
 
       - name: Cd to docs
         run: cd docs

--- a/sh/fix_redoc.py
+++ b/sh/fix_redoc.py
@@ -5,11 +5,13 @@ import sys
 import yaml
 import json
 
+fix_targets = ["application/json", "application/hal+json","application/json;charset=UTF-8"]
+
 def fix_examples(res: dict):
     for key, value in res.items():
         if isinstance(value, dict):
             fix_examples(value)
-        if key == "application/json":
+        if key in fix_targets:
             for example_name, content in value["examples"].items():
                 try:
                     content["value"] = json.loads(content["value"])


### PR DESCRIPTION
기존에 사용하던 수정 파이썬 스크립트가 오직 application/json타입만 수정하여
해당 api에서 사용하는 application/hal+json 유형을 제대로 처리하지 못하는 문제를 수정함