### PR TITLE
[CHORE] live test 를 위한 프로필 추가 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ application.properties
 application-test.properties
 application-product.properties
 application-local.properties
+application-liveTest.properties
 logback-local.xml
 logback-test.xml
 logback-product.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ ENV TZ=Asia/Seoul
 WORKDIR /app
 COPY ./libs/*.jar app.jar
 EXPOSE 8080
-RUN mkdir ./images
+ENV	USE_PROFILE product
 
-ENTRYPOINT ["java","-Dspring.profiles.active=product","-Duser.timezone=Asia/Seoul","-jar","/app/app.jar"]a","-Dspring.profiles.active=product","-Duser.timezone=Asia/Seoul","-jar","/app.jar"]
+ENTRYPOINT ["java","-Dspring.profiles.active=${USE_PROFILE}","-Duser.timezone=Asia/Seoul","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,20 @@ services:
     restart: always
     networks:
       - springnote_net
-    volumes:
-      - springnote_image:/app/images
+    environment:
+      - USE_PROFILE=production
+    labels:
+      logging: "promtail"
+      logging_jobname: "containerlogs"
+
+  springnote-test:
+    image: springnote-api:latest
+    container_name: springnote-test
+    restart: always
+    networks:
+      - springnote_net
+    environment:
+      - USE_PROFILE=liveTest
     labels:
       logging: "promtail"
       logging_jobname: "containerlogs"
@@ -16,6 +28,3 @@ networks:
   springnote_net:
     external: true
 
-volumes:
-  springnote_image:
-    external: true


### PR DESCRIPTION
live test용 db 추가 및 계정 분리에 따라 배포시 live test용 컨테이너도 함께 배포 하도록 추가

이때 프로필를 따로 사용할 수 있도록 추가