### PR TITLE
[FEAT] 본문 최대 길이 제한 증가

### DIFF
--- a/src/main/java/com/springnote/api/dto/post/controller/PostCreateRequestControllerDto.java
+++ b/src/main/java/com/springnote/api/dto/post/controller/PostCreateRequestControllerDto.java
@@ -36,7 +36,7 @@ public class PostCreateRequestControllerDto {
     @ListSizeCheck(min = 0, max = 10, message = "태그는 최대 10개까지 설정할 수 있습니다.", nullable = true)
     private List<PostTagId> tags = new LinkedList<PostTagId>();
 
-    @Size(min = 3, max = 30000, message = "본문은 3자 이상, 30000자 이하여야 합니다.")
+    @Size(min = 3, max = 65535, message = "본문은 3자 이상, 65535자 이하여야 합니다.")
     @NotEmpty(message = "본문을 입력해주세요.")
     private String content;
 

--- a/src/main/java/com/springnote/api/dto/post/controller/PostUpdateRequestControllerDto.java
+++ b/src/main/java/com/springnote/api/dto/post/controller/PostUpdateRequestControllerDto.java
@@ -39,7 +39,7 @@ public class PostUpdateRequestControllerDto {
     @ListSizeCheck(min = 0, max = 10, message = "태그는 최대 10개까지 설정할 수 있습니다.", nullable = true)
     private List<PostTagId> tags = new LinkedList<PostTagId>();
 
-    @Size(min = 3, max = 30000, message = "본문은 3자 이상, 30000자 이하여야 합니다.")
+    @Size(min = 3, max = 65535, message = "본문은 3자 이상, 65535자 이하여야 합니다.")
     @NotEmpty(message = "본문을 입력해주세요.")
     private String content;
 

--- a/src/main/java/com/springnote/api/dto/tmpPost/controller/TmpPostCreateRequestControllerDto.java
+++ b/src/main/java/com/springnote/api/dto/tmpPost/controller/TmpPostCreateRequestControllerDto.java
@@ -34,7 +34,7 @@ public class TmpPostCreateRequestControllerDto {
     @ListSizeCheck(min = 0, max = 10, message = "태그는 최대 10개까지 설정할 수 있습니다.", nullable = true)
     private List<PostTagId> tagIds;
 
-    @Size(max = 30000, message = "본문은 30000자 이하여야 합니다.")
+    @Size(max = 65535, message = "본문은 65535자 이하여야 합니다.")
     private String content;
 
     @Size(max = 300, message = "제목은 300자 이하여야 합니다.")

--- a/src/main/java/com/springnote/api/dto/tmpPost/controller/TmpPostUpdateRequestControllerDto.java
+++ b/src/main/java/com/springnote/api/dto/tmpPost/controller/TmpPostUpdateRequestControllerDto.java
@@ -31,7 +31,7 @@ public class TmpPostUpdateRequestControllerDto {
     @ListSizeCheck(min = 0, max = 10, message = "태그는 최대 10개까지 설정할 수 있습니다.", nullable = true)
     private List<PostTagId> tagIds;
 
-    @Size(max = 30000, message = "본문은 30000자 이하여야 합니다.")
+    @Size(max = 65535, message = "본문은 65535자 이하여야 합니다.")
     private String content;
 
     @Size(max = 300, message = "제목은 300자 이하여야 합니다.")

--- a/src/test/java/com/springnote/api/tests/controller/PostApiControllerTest.java
+++ b/src/test/java/com/springnote/api/tests/controller/PostApiControllerTest.java
@@ -845,7 +845,7 @@ public class PostApiControllerTest extends ControllerTestTemplate {
                                     .requestFields(
                                             fieldWithPath("series_id").type(NUMBER).description("포스트의 시리즈 ID, 만약 시리즈가 필요 없는 포스트는 null").optional(),
                                             fieldWithPath("title").type(STRING).description("포스트의 제목, 3~300자"),
-                                            fieldWithPath("content").type(STRING).description("포스트의 내용, 3~30000자"),
+                                            fieldWithPath("content").type(STRING).description("포스트의 내용, 3~65535자"),
                                             fieldWithPath("tags").type(ARRAY).description("포스트의 태그 ID 리스트"),
                                             fieldWithPath("tags[].id").type(NUMBER).description("포스트의 태그 ID"),
                                             fieldWithPath("enabled").type(BOOLEAN).description("포스트의 공개 여부"),
@@ -924,7 +924,7 @@ public class PostApiControllerTest extends ControllerTestTemplate {
             tooShortContent.setContent("a");
 
             var tooLongContent = copyPostCreateRequestControllerDto(base);
-            tooLongContent.setContent("a".repeat(30001));
+            tooLongContent.setContent("a".repeat(65536));
 
             var invalidThumbnail = copyPostCreateRequestControllerDto(base);
             invalidThumbnail.setThumbnail("a".repeat(301));
@@ -943,7 +943,7 @@ public class PostApiControllerTest extends ControllerTestTemplate {
                     Arguments.of(tooShortTitle, "제목이 2자 미만인 경우"),
                     Arguments.of(tooLongTitle, "제목이 300자를 초과하는 경우"),
                     Arguments.of(tooShortContent, "내용이 2자 미만인 경우"),
-                    Arguments.of(tooLongContent, "내용이 30000자를 초과하는 경우"),
+                    Arguments.of(tooLongContent, "내용이 65535자를 초과하는 경우"),
                     Arguments.of(invalidThumbnail, "썸네일이 300자를 초과하는 경우"),
                     Arguments.of(nullIsEnabled, "공개 여부가 null 인 경우")
             );
@@ -1061,7 +1061,7 @@ public class PostApiControllerTest extends ControllerTestTemplate {
                                     .requestFields(
                                             fieldWithPath("series_id").type(NUMBER).description("포스트의 시리즈 ID, 만약 시리즈가 필요 없는 포스트는 null").optional(),
                                             fieldWithPath("title").type(STRING).description("포스트의 제목, 3~300자"),
-                                            fieldWithPath("content").type(STRING).description("포스트의 내용, 3~30000자"),
+                                            fieldWithPath("content").type(STRING).description("포스트의 내용, 3~65535자"),
                                             fieldWithPath("tags").type(ARRAY).description("포스트의 태그 ID 리스트"),
                                             fieldWithPath("tags[].id").type(NUMBER).description("포스트의 태그 ID"),
                                             fieldWithPath("enabled").type(BOOLEAN).description("포스트의 공개 여부"),
@@ -1166,7 +1166,7 @@ public class PostApiControllerTest extends ControllerTestTemplate {
             tooShortContent.setContent("a");
 
             var tooLongContent = copyPostUpdateRequestControllerDto(base);
-            tooLongContent.setContent("a".repeat(30001));
+            tooLongContent.setContent("a".repeat(65536));
 
             var invalidThumbnail = copyPostUpdateRequestControllerDto(base);
             invalidThumbnail.setThumbnail("a".repeat(301));
@@ -1183,7 +1183,7 @@ public class PostApiControllerTest extends ControllerTestTemplate {
                     Arguments.of(tooShortTitle, "제목이 2자 미만인 경우"),
                     Arguments.of(tooLongTitle, "제목이 300자를 초과하는 경우"),
                     Arguments.of(tooShortContent, "내용이 2자 미만인 경우"),
-                    Arguments.of(tooLongContent, "내용이 30000자를 초과하는 경우"),
+                    Arguments.of(tooLongContent, "내용이 65535자를 초과하는 경우"),
                     Arguments.of(invalidThumbnail, "썸네일이 300자를 초과하는 경우"),
                     Arguments.of(nullIsEnabled, "공개 여부가 null 인 경우")
             );

--- a/src/test/java/com/springnote/api/tests/controller/TmpPostApiControllerTest.java
+++ b/src/test/java/com/springnote/api/tests/controller/TmpPostApiControllerTest.java
@@ -110,7 +110,7 @@ public class TmpPostApiControllerTest extends ControllerTestTemplate {
                                             fieldWithPath("post_type_id").description("포스트 타입 ID"),
                                             fieldWithPath("series_id").description("시리즈 ID"),
                                             fieldWithPath("tag_ids").description("태그 ID 목록"),
-                                            fieldWithPath("content").description("본문 30000자 이내"),
+                                            fieldWithPath("content").description("본문 65535자 이내"),
                                             fieldWithPath("title").description("제목 300자 이내"),
                                             fieldWithPath("thumbnail").description("썸네일 주소")
                                     )
@@ -146,7 +146,7 @@ public class TmpPostApiControllerTest extends ControllerTestTemplate {
 
             var tooLongContent = TmpPostCreateRequestControllerDto
                     .builder()
-                    .content("a".repeat(30001))
+                    .content("a".repeat(65536))
                     .postTypeId(1L)
                     .build();
 
@@ -190,7 +190,7 @@ public class TmpPostApiControllerTest extends ControllerTestTemplate {
 
             return Stream.of(
                     Arguments.of(tooLongTitle, "300자가 넘는 제목"),
-                    Arguments.of(tooLongContent, "30000자가 넘는 본문"),
+                    Arguments.of(tooLongContent, "65535자가 넘는 본문"),
                     Arguments.of(invalidPostTypeId, "0인 postTypeId"),
                     Arguments.of(tooLargePostTypeId, "TINYINT의 최대 값보다 큰 postTypeId"),
                     Arguments.of(noPostTypeId, "postTypeId가 없는 요청"),
@@ -545,7 +545,7 @@ public class TmpPostApiControllerTest extends ControllerTestTemplate {
                                     .requestFields(
                                             fieldWithPath("series_id").description("시리즈 ID").optional(),
                                             fieldWithPath("tag_ids").description("태그 ID 목록").optional(),
-                                            fieldWithPath("content").description("본문 30000자 이내"),
+                                            fieldWithPath("content").description("본문 65535자 이내"),
                                             fieldWithPath("title").description("제목 300자 이내"),
                                             fieldWithPath("thumbnail").description("썸네일 주소")
                                     )
@@ -578,7 +578,7 @@ public class TmpPostApiControllerTest extends ControllerTestTemplate {
 
             var tooLongContent = TmpPostUpdateRequestControllerDto
                     .builder()
-                    .content("a".repeat(30001))
+                    .content("a".repeat(65536))
                     .build();
 
             var tooManyTags = TmpPostUpdateRequestControllerDto
@@ -605,7 +605,7 @@ public class TmpPostApiControllerTest extends ControllerTestTemplate {
 
             return Stream.of(
                     Arguments.of(tooLongTitle, "300자가 넘는 제목"),
-                    Arguments.of(tooLongContent, "30000자가 넘는 본문"),
+                    Arguments.of(tooLongContent, "65535자가 넘는 본문"),
                     Arguments.of(tooManyTags, "태그가 10개 초과인 요청"),
                     Arguments.of(invalidThumbnail, "유효하지 않은 썸네일 주소")
             );


### PR DESCRIPTION
기존 본문 제한 30000자에서 mariadb 기준 text필드 최대치인 65535 으로 확장. 이에따라 post dto 및 tmp post dto 제약요건 수정