### PR TITLE
[FIX] tmpPost 수정시 Series가 null이면 오류가 발생하는 문제 수정

### DIFF
--- a/src/main/java/com/springnote/api/service/TmpPostService.java
+++ b/src/main/java/com/springnote/api/service/TmpPostService.java
@@ -177,7 +177,7 @@ public class TmpPostService {
                 .content(targetTmpPost.getContent())
                 .title(targetTmpPost.getTitle())
                 .thumbnail(targetTmpPost.getThumbnail())
-                .seriesId(targetTmpPost.getSeries().getId())
+                .seriesId((targetTmpPost.getSeries()== null) ? null : targetTmpPost.getSeries().getId())
                 .tagIds(targetTmpPost.getTmpPostTags().stream().map(tmpPostTag -> tmpPostTag.getTag().getId()).toList())
                 .postTypeId(targetTmpPost.getPostType().getId())
                 .isEnabled(true)
@@ -227,9 +227,7 @@ public class TmpPostService {
 
     }
 
-    private boolean isViolateNeedSeriesPolicy(PostType postType, Long seriesId) {
-        return (postType.isNeedSeries() && seriesId == null) || (!postType.isNeedSeries() && seriesId != null);
-    }
+  
 
     private boolean isExistAllTag(List<Long> tagIds, List<Tag> tags) {
         return tagIds.size() == tags.size();
@@ -283,7 +281,9 @@ public class TmpPostService {
 
     private boolean isNeedUpdateSeries(TmpPost tmpPost, Long newId) {
         if (!tmpPost.getPostType().isNeedSeries()) return false;
-        return !tmpPost.getSeries().getId().equals(newId);
+        if(tmpPost.getSeries() == null && newId == null) return false;
+
+        return tmpPost.getSeries() == null || !tmpPost.getSeries().getId().equals(newId);
     }
 
 


### PR DESCRIPTION
기존 tmpPost 수정시 Series가 null이면 오류가 발생하여 만약 기존 시리즈와 새로운 id 모두 null이면 업데이트 로직을 수행하지 않게 수정