### PR TITLE
[FIX] 회원가입시 비활성화된 유저가 다시 회원가입되는 오류 수정, 유저 정보 조회시 비활성화된 유저도 가능하도록 수정

### DIFF
--- a/src/main/java/com/springnote/api/aop/auth/AuthLevel.java
+++ b/src/main/java/com/springnote/api/aop/auth/AuthLevel.java
@@ -1,5 +1,12 @@
 package com.springnote.api.aop.auth;
 
+/**
+ * 권한 레벨
+ * <p>
+ * NONE : 인증 없이 접근 가능 ( 인증이 필수는 아니나, 사용자 정보가 필요한 경우 사용 )
+ * USER : 서비스내 등록이 된 사용자만 접근 가능
+ * ADMIN : 관리자만 접근 가능
+ */
 public enum AuthLevel {
     NONE, USER, ADMIN
 }

--- a/src/main/java/com/springnote/api/aop/auth/EnableAuthentication.java
+++ b/src/main/java/com/springnote/api/aop/auth/EnableAuthentication.java
@@ -2,9 +2,20 @@ package com.springnote.api.aop.auth;
 
 import java.lang.annotation.*;
 
+
+/**
+ * 해당 메소드에 대한 인증을 활성화 합니다.
+ *
+ * @see AuthLevel
+ * @see EnableAuthAspect
+ */
 @Inherited
 @Retention(value = RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface EnableAuthentication {
+    // 권한 레벨
     AuthLevel value() default AuthLevel.NONE;
+
+    // 비활성화된 사용자의 요청을 허용할지 여부
+    boolean isAllowDisableUser() default false;
 }

--- a/src/main/java/com/springnote/api/dto/user/common/UserSimpleResponseCommonDto.java
+++ b/src/main/java/com/springnote/api/dto/user/common/UserSimpleResponseCommonDto.java
@@ -16,4 +16,5 @@ public class UserSimpleResponseCommonDto {
     private String displayName;
     private String profileImg;
     private boolean isAdmin;
+    private boolean isEnabled;
 }

--- a/src/main/java/com/springnote/api/utils/context/UserContext.java
+++ b/src/main/java/com/springnote/api/utils/context/UserContext.java
@@ -25,6 +25,7 @@ public class UserContext {
     private String uid;
     private String displayName;
     private String profileImg;
+    private boolean isEnabled;
 
     // 실제 로직에서 사용하는 사용자 정보가 아닌, 단순 firebase 정보임
     private String fbUid;
@@ -46,6 +47,7 @@ public class UserContext {
         this.displayName = userResponseCommonDto.getName();
         this.isAdmin = userResponseCommonDto.isAdmin();
         this.profileImg = userResponseCommonDto.getProfileImg();
+        this.isEnabled = userResponseCommonDto.isEnabled();
 
     }
 
@@ -54,6 +56,7 @@ public class UserContext {
         this.displayName = null;
         this.isAdmin = false;
         this.profileImg = null;
+        this.isEnabled = false;
     }
 
     public UserSimpleResponseCommonDto toDto() {
@@ -62,6 +65,7 @@ public class UserContext {
                 .displayName(displayName)
                 .profileImg(profileImg)
                 .isAdmin(isAdmin)
+                .isEnabled(isEnabled)
                 .build();
     }
 

--- a/src/main/java/com/springnote/api/web/controller/AuthApiController.java
+++ b/src/main/java/com/springnote/api/web/controller/AuthApiController.java
@@ -32,7 +32,7 @@ public class AuthApiController {
     private final AuthConfig authConfig;
 
 
-    @EnableAuthentication(AuthLevel.NONE)
+    @EnableAuthentication(value = AuthLevel.NONE, isAllowDisableUser = true)
     @PostMapping
     public ResponseEntity<Void> register(
             @NotEmpty
@@ -81,7 +81,7 @@ public class AuthApiController {
         }
     }
 
-    @EnableAuthentication(AuthLevel.USER)
+    @EnableAuthentication(value = AuthLevel.USER, isAllowDisableUser = true)
     @GetMapping
     public ResponseEntity<UserSimpleResponseCommonDto> getSelfInfo() {
 

--- a/src/test/java/com/springnote/api/tests/controller/AuthApiControllerTest.java
+++ b/src/test/java/com/springnote/api/tests/controller/AuthApiControllerTest.java
@@ -300,18 +300,15 @@ public class AuthApiControllerTest extends ControllerTestTemplate {
             var testDisplayName = "testDisplayName";
             var testIsAdmin = false;
             var testProfileImage = "testProfileImage";
+            var testEnabled = true;
 
-//            doReturn(testUid).when(userContext).getUid();
-//            doReturn(testDisplayName).when(userContext).getDisplayName();
-//            doReturn(testIsAdmin).when(userContext).isAdmin();
-//            doReturn(testProfileImage).when(userContext).getProfileImg();
-//
             doReturn(UserSimpleResponseCommonDto
                     .builder()
                     .uid(testUid)
                     .displayName(testDisplayName)
                     .isAdmin(testIsAdmin)
                     .profileImg(testProfileImage)
+                    .isEnabled(testEnabled)
                     .build()).when(userContext).toDto();
 
 
@@ -329,7 +326,8 @@ public class AuthApiControllerTest extends ControllerTestTemplate {
                                             fieldWithPath("uid").type(STRING).description("유저 uid"),
                                             fieldWithPath("display_name").type(STRING).description("유저 이름"),
                                             fieldWithPath("profile_img").type(STRING).description("프로필 이미지"),
-                                            fieldWithPath("admin").type(BOOLEAN).description("관리자 여부")
+                                            fieldWithPath("admin").type(BOOLEAN).description("관리자 여부"),
+                                            fieldWithPath("enabled").type(BOOLEAN).description("계정 활성화 여부")
                                     )
                                     .summary("자신의 정보를 반환합니다. (AUTH-LEVEL : USER)")
                                     .build())


### PR DESCRIPTION

회원가입시 비활성화된 유저가 다시 회원가입되는 오류 수정

기존 인증방식에서 비활성화된 유저가 토큰은 유효하나, 회원가입이 안된 상태로 인식되어 비활성화 상태에서 재 가입으로 비활성화를 해제하는 버그가 있어 수정

유저 정보 조회시 비활성화된 유저도 가능하도록 수정

클라이언트에서 비활성화된 유저 감별을 위해 사용